### PR TITLE
🔒 Update BBC RSS feed to use HTTPS

### DIFF
--- a/config.sh
+++ b/config.sh
@@ -42,7 +42,7 @@ declare -gA HCNEWS_FEEDS=(
     ["newyorker"]="https://www.newyorker.com/feed/magazine/rss"
     ["folha"]="https://feeds.folha.uol.com.br/mundo/rss091.xml"
     ["formula1"]="https://www.formula1.com/content/fom-website/en/latest/all.xml"
-    ["bbc"]="http://feeds.bbci.co.uk/news/world/latin_america/rss.xml"
+    ["bbc"]="https://feeds.bbci.co.uk/news/world/latin_america/rss.xml"
 )
 
 # -----------------------------------------------------------------------------

--- a/hcnews.sh
+++ b/hcnews.sh
@@ -626,7 +626,7 @@ if [[ -v HCNEWS_FEEDS[@] ]]; then
     newyorker="${HCNEWS_FEEDS[newyorker]:-https://www.newyorker.com/feed/magazine/rss}"
     folha="${HCNEWS_FEEDS[folha]:-https://feeds.folha.uol.com.br/mundo/rss091.xml}"
     formula1="${HCNEWS_FEEDS[formula1]:-https://www.formula1.com/content/fom-website/en/latest/all.xml}"
-    bcc="${HCNEWS_FEEDS[bbc]:-http://feeds.bbci.co.uk/news/world/latin_america/rss.xml}"
+    bcc="${HCNEWS_FEEDS[bbc]:-https://feeds.bbci.co.uk/news/world/latin_america/rss.xml}"
 else
     o_popular="https://opopularpr.com.br/feed/"
     plantao190="https://plantao190.com.br/feed/"
@@ -637,7 +637,7 @@ else
     newyorker="https://www.newyorker.com/feed/magazine/rss"
     folha="https://feeds.folha.uol.com.br/mundo/rss091.xml"
     formula1="https://www.formula1.com/content/fom-website/en/latest/all.xml"
-    bcc="http://feeds.bbci.co.uk/news/world/latin_america/rss.xml"
+    bcc="https://feeds.bbci.co.uk/news/world/latin_america/rss.xml"
 fi
 
 # Build all_feeds from comma-separated feed keys


### PR DESCRIPTION
🎯 **What:** The BBC RSS feed URL was using the insecure `http://` protocol.
⚠️ **Risk:** Using `http://` allows for man-in-the-middle (MITM) attacks, where an attacker could intercept or modify the news feed content.
🛡️ **Solution:** Updated the BBC RSS feed URL to use `https://` in `config.sh` and `hcnews.sh`.

---
*PR created automatically by Jules for task [56352704072764560](https://jules.google.com/task/56352704072764560) started by @herijooj*