### PR TITLE
feat: Add support for images in Did You Know section for HTML output

### DIFF
--- a/.github/template.html
+++ b/.github/template.html
@@ -367,6 +367,8 @@
             parsed = parsed.replace(/\*([^*\n]+)\*/g, '<strong>$1</strong>');
             parsed = parsed.replace(/_([^_]+)_/g, '<em>$1</em>');
             parsed = parsed.replace(/~([^~\n]+)~/g, '<del>$1</del>');
+            const imgRegex = /!\[([^\]]*)\]\((https?:\/\/[^\s)]+)\)/g;
+            parsed = parsed.replace(imgRegex, '<img src="$2" alt="$1" style="max-width:100%;height:auto;display:block;margin-top:10px;">');
             const titleInlineRegex = /-\s+([^\n\r]*?[a-zA-Z0-9][^\n\r]*?)\s+(https?:\/\/[^\s]+)/g;
             parsed = parsed.replace(titleInlineRegex, '- <a href="$2" target="_blank">$1</a>');
             const titlePairRegex = /^-\s+([^\n\r]+)\r?\n\s+(https?:\/\/[^\s]+)/gm;

--- a/build_daily.sh
+++ b/build_daily.sh
@@ -4,6 +4,9 @@
 SCRIPT_DIR=$(dirname "$(realpath "${BASH_SOURCE[0]}")")
 source "$SCRIPT_DIR/hcnews.sh"
 
+# Set HTML output mode to enable enhanced content (e.g. images in Did You Know)
+export HCNEWS_HTML_OUTPUT=true
+
 # Fetch common data once
 # Start main data fetch in background or parallel to horoscope?
 # hcnews.sh functions use global variables, so running fetch_newspaper_data in background might be tricky if we need to access them here.


### PR DESCRIPTION
This change enhances the "Did You Know" section by embedding relevant images in the generated HTML output while keeping the text (terminal) output unchanged.

Changes:
- Modified `scripts/didyouknow.sh` to fetch wikitext and extract image URLs if the selected fact contains `(imagem)`.
- Added `HCNEWS_HTML_OUTPUT` environment variable support to `scripts/didyouknow.sh` to trigger image inclusion and use a separate cache key (`didyouknow_html`).
- Updated `build_daily.sh` to export `HCNEWS_HTML_OUTPUT=true` for HTML generation.
- Updated `.github/template.html` to support markdown image syntax `![alt](url)` in the `parseWhatsApp` function.

---
*PR created automatically by Jules for task [1270718357827674179](https://jules.google.com/task/1270718357827674179) started by @herijooj*