### PR TITLE
fix(scraper): Update Vatican News CSS selectors in saints.sh

### DIFF
--- a/scripts/saints.sh
+++ b/scripts/saints.sh
@@ -32,13 +32,13 @@ _saints_fetch_html() {
 
 _saints_extract_names() {
 	local html="$1"
-	echo "$html" | pup '.section__head h2 text{}' | sed -E 's/^[[:space:]]+//; s/[[:space:]]+$//; s/[[:space:]][[:space:]]+/ /g' | sed '/^$/d'
+	echo "$html" | pup '.section--isStatic h2 text{}' | sed -E 's/^[[:space:]]+//; s/[[:space:]]+$//; s/[[:space:]][[:space:]]+/ /g' | sed '/^$/d'
 }
 
 _saints_extract_descriptions() {
 	local html="$1"
 	local description
-	description=$(echo "$html" | pup '.section__head h2 text{}, .section__content p text{}' | sed '/^$/d' | sed '1d' | sed '/^[[:space:]]*$/d')
+	description=$(echo "$html" | pup '.section--isStatic .section__content p text{}' | sed '/^$/d' | sed '/^[[:space:]]*$/d')
 	hcnews_decode_html_entities "$description"
 }
 


### PR DESCRIPTION
This PR fixes the `scripts/saints.sh` scraping logic. The Vatican News website layout changed, and the `.section__head` classes were no longer functioning correctly to retrieve the names and descriptions of saints.

**🎯 What:** Update `pup` CSS selectors in `_saints_extract_names` and `_saints_extract_descriptions` to target the `.section--isStatic` element structure.
**💡 Why:** The target site's layout has changed, which was causing the script to return `⚠️ Não foi possível encontrar santos para hoje.`
**✅ Verification:** Ran `bash scripts/saints.sh -v` and confirmed accurate retrieval of saint names and descriptions. Also ran `bash -n scripts/saints.sh` to check for syntax errors. Tested without any artifacts left behind.

---
*PR created automatically by Jules for task [10811300216151347492](https://jules.google.com/task/10811300216151347492) started by @herijooj*